### PR TITLE
Fix run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project contains a Vue SPA that uses [this](https://github.com/agile-learni
 To run the API and Test Database locally, you can use the following command. See [here for details](https://github.com/agile-learning-institute/institute/blob/main/docker-compose/README.md) on how to stop/start the database.
 
 ```bash
-/bin/bash =(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) person-api
+/bin/bash <(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) person-api
 ```
 
 ## Build and Run the UI

--- a/src/docker/docker-build.sh
+++ b/src/docker/docker-build.sh
@@ -7,4 +7,4 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-/bin/bash =(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) person
+/bin/bash <(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) person


### PR DESCRIPTION
The prior syntax is specific to zsh and creates a true temporary file. This change allows the commands to run on bash as well.