### PR TITLE
Updated to use templates folder

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN npm run build
 # Get branch and patch level, then create patch.txt file
 RUN BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
     DATE=$(date "+%Y-%m-%d:%H:%M:%S") && \
-    echo $DATE.$PATCH > ./dist/patch.txt
+    echo $DATE.$BRANCH > ./dist/patch.txt
 
 # Deployment stage
 FROM nginx:stable-alpine as deploy

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -22,11 +22,13 @@ RUN BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
 # Deployment stage
 FROM nginx:stable-alpine as deploy
 
+# Default Environment Variable values
+ENV API_HOST = mentorhub-persion-api 
+ENV API_PORT 8083
+
 # Copy built assets from build stage to nginx serving directory
 COPY --from=build /app/dist /usr/share/nginx/html
-# COPY --from=build /app/src/docker/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/src/docker/default.conf.template /etc/nginx/templates/default.conf.template
-# COPY --from=build /app/src/docker/nginx.conf /etc/nginx/nginx.conf
 
 # Expose port 80
 EXPOSE 80

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -24,7 +24,8 @@ FROM nginx:stable-alpine as deploy
 
 # Copy built assets from build stage to nginx serving directory
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY --from=build /app/src/docker/default.conf /etc/nginx/conf.d/default.conf
+# COPY --from=build /app/src/docker/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/src/docker/default.conf.template /etc/nginx/templates/default.conf.template
 # COPY --from=build /app/src/docker/nginx.conf /etc/nginx/nginx.conf
 
 # Expose port 80

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -15,9 +15,8 @@ RUN npm run build
 
 # Get branch and patch level, then create patch.txt file
 RUN BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
-    PATCH=$(git rev-parse HEAD) && \
     DATE=$(date "+%Y-%m-%d:%H:%M:%S") && \
-    echo $DATE.$BRANCH.$PATCH > ./dist/patch.txt
+    echo $DATE.$PATCH > ./dist/patch.txt
 
 # Deployment stage
 FROM nginx:stable-alpine as deploy

--- a/src/docker/default.conf.template
+++ b/src/docker/default.conf.template
@@ -29,6 +29,6 @@ server {
     error_log /var/log/nginx/error.log;
 
     location /api/ {
-        proxy_pass http://mentorhub-person-api:8082/api/;
+        proxy_pass http://${API_HOST}:${API_PORT}/api/;
     }
 }


### PR DESCRIPTION
NGINX container supports templates using envsubst templates - the container now honors API_HOST and API_PORT environment variables. 

Feature of [official NGNIX container](https://hub.docker.com/_/nginx): under "Using environment variables in nginx configuration"